### PR TITLE
Fix #15: Add a way to flush metabug cache

### DIFF
--- a/src/content/components/Router/Router.js
+++ b/src/content/components/Router/Router.js
@@ -27,6 +27,12 @@ const RouterNav = withRouter(class _RouterNav extends React.PureComponent {
       {route.label}
     </NavLink></li>);
   }
+
+  async refreshMetas() {
+    await fetch('/refresh_metas');
+    window.location.reload();
+  }
+
   render() {
     const {routes} = this.props;
     return (<nav className={styles.aside}>
@@ -37,6 +43,9 @@ const RouterNav = withRouter(class _RouterNav extends React.PureComponent {
         <li><a className={styles.navLink} href="https://github.com/k88hudson/bugzy/issues">
           <span className={styles.icon + " " + styles["icon-alert"]} />
           Report an issue
+        </a></li>
+        <li><a className={styles.navLink} onClick={this.refreshMetas} href="">
+          Refresh metabugs
         </a></li>
       </ul>
     </nav>);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -39,6 +39,12 @@ app.get('/api/metas', async (req, res) => {
   res.send(metasCache.data);
 });
 
+app.get('/refresh_metas', (req, res) => {
+  metasCache.data = null;
+  metasCache.lastUpdated = null;
+  res.end();
+});
+
 app.post('/api/bugs', async (req, res) => {
   const data = await fetchQuery(req.body);
   res.send(data);


### PR DESCRIPTION
There's no icon at the moment, but this was the most straightforward solution I could think of.