### PR TITLE
followup(#58) - Add Exception for 63 long cycle

### DIFF
--- a/src/common/iterationUtils.js
+++ b/src/common/iterationUtils.js
@@ -48,7 +48,11 @@ function getIterationEstimatesWeeks(major) {
     };
   }
 
-  return {MAJOR_IN_WEEKS, MINOR_IN_WEEKS};
+  return {
+    MAJOR_IN_WEEKS,
+    MINOR_IN_WEEKS,
+    MINORS_PER_MAJOR
+  };
 }
 
 function getDatesForIteration(iteration: string) {
@@ -126,7 +130,7 @@ function getAdjacentIteration(diff : number, date : Date | string) {
   major = +major;
   minor = +minor;
 
-  const convertedNumber = ((major + (minor - 1) / MINORS_PER_MAJOR) + diff / MINORS_PER_MAJOR).toFixed(1);
+  const convertedNumber = parseFloat(((major + (minor - 1) / MINORS_PER_MAJOR) + diff / MINORS_PER_MAJOR).toFixed(1));
 
   const newMajor = Math.floor(convertedNumber);
   const newMinor = Math.round((convertedNumber - newMajor) * MINORS_PER_MAJOR + 1);

--- a/src/common/iterationUtils.js
+++ b/src/common/iterationUtils.js
@@ -32,14 +32,28 @@ const POST_63_REFERENCE_ITERATION = {
 
 // Track exceptions to the development cycle
 const EXCEPTIONS = {
-  "63": {MAJOR_IN_WEEKS: 10}
+  "63": {MAJOR_IN_WEEKS: 10, MINORS_PER_MAJOR: 5}
 }
 
-const MAJOR_IN_WEEKS = 8;
-const MINOR_IN_WEEKS = 2;
+function getIterationEstimatesWeeks(major) {
+  const MAJOR_IN_WEEKS = 8;
+  const MINOR_IN_WEEKS = 2;
+  const MINORS_PER_MAJOR = 4;
+
+  if (EXCEPTIONS[major]) {
+    return {
+      MAJOR_IN_WEEKS: EXCEPTIONS[major].MAJOR_IN_WEEKS || MAJOR_IN_WEEKS,
+      MINOR_IN_WEEKS: EXCEPTIONS[major].MINOR_IN_WEEKS || MINOR_IN_WEEKS,
+      MINORS_PER_MAJOR: EXCEPTIONS[major].MINORS_PER_MAJOR || MINORS_PER_MAJOR
+    };
+  }
+
+  return {MAJOR_IN_WEEKS, MINOR_IN_WEEKS};
+}
 
 function getDatesForIteration(iteration: string) {
   const [major, minor] = iteration.split(".").map(i => parseInt(i));
+  const {MAJOR_IN_WEEKS, MINOR_IN_WEEKS} = getIterationEstimatesWeeks(major);
 
   const reference = major >= 63 ? POST_63_REFERENCE_ITERATION : REFERENCE_ITERATION;
 
@@ -91,13 +105,10 @@ function getIteration(date : Date | string) {
   const monday = actualDate.minus({days: actualDate.weekday - 1});
 
   const timeSinceReference = monday.diff(reference.start, ["weeks"]).toObject();
-  let release_length_weeks = MAJOR_IN_WEEKS;
-  if (EXCEPTIONS[reference.major]) {
-    release_length_weeks = EXCEPTIONS[reference.major].MAJOR_IN_WEEKS;
-  }
+  const {MAJOR_IN_WEEKS, MINOR_IN_WEEKS} = getIterationEstimatesWeeks(reference.major);
   const result = {
-    major: reference.major + (Math.floor(timeSinceReference.weeks / release_length_weeks) || 0),
-    minor: (Math.floor((timeSinceReference.weeks % release_length_weeks) / MINOR_IN_WEEKS) || 0) + 1
+    major: reference.major + (Math.floor(timeSinceReference.weeks / MAJOR_IN_WEEKS) || 0),
+    minor: (Math.floor((timeSinceReference.weeks % MAJOR_IN_WEEKS) / MINOR_IN_WEEKS) || 0) + 1
   };
   const number = `${result.major}.${result.minor}`;
   const {start, due} = getDatesForIteration(number);
@@ -109,9 +120,9 @@ function getIteration(date : Date | string) {
 }
 
 function getAdjacentIteration(diff : number, date : Date | string) {
-  const MINORS_PER_MAJOR = 4;
   const current = getIteration(date);
   let [major, minor] = current.number.split(".");
+  const {MINORS_PER_MAJOR} = getIterationEstimatesWeeks(major);
   major = +major;
   minor = +minor;
 

--- a/src/common/iterationUtils.js
+++ b/src/common/iterationUtils.js
@@ -126,10 +126,10 @@ function getAdjacentIteration(diff : number, date : Date | string) {
   major = +major;
   minor = +minor;
 
-  const convertedNumber = (major + (minor - 1) / MINORS_PER_MAJOR) + diff / MINORS_PER_MAJOR;
+  const convertedNumber = ((major + (minor - 1) / MINORS_PER_MAJOR) + diff / MINORS_PER_MAJOR).toFixed(1);
 
   const newMajor = Math.floor(convertedNumber);
-  const newMinor = (convertedNumber - newMajor) * MINORS_PER_MAJOR + 1;
+  const newMinor = Math.round((convertedNumber - newMajor) * MINORS_PER_MAJOR + 1);
   const number = `${newMajor}.${newMinor}`;
   const {start, due} = getDatesForIteration(number);
   return {


### PR DESCRIPTION
There was also a `MINORS_PER_MAJOR` exception and `getAdjacentIteration` had some issues rouding down "minor" numbers.