### PR TITLE
Fetch the correct iteration exceptions. Fixes #63

### DIFF
--- a/src/common/iterationUtils.js
+++ b/src/common/iterationUtils.js
@@ -35,7 +35,7 @@ const EXCEPTIONS = {
   "63": {MAJOR_IN_WEEKS: 10, MINORS_PER_MAJOR: 5}
 }
 
-function getIterationEstimatesWeeks(major) {
+function getIterationEstimatesWeeks(major: number) {
   const MAJOR_IN_WEEKS = 8;
   const MINOR_IN_WEEKS = 2;
   const MINORS_PER_MAJOR = 4;
@@ -126,7 +126,7 @@ function getIteration(date : Date | string) {
 function getAdjacentIteration(diff : number, date : Date | string) {
   const current = getIteration(date);
   let [major, minor] = current.number.split(".");
-  const {MINORS_PER_MAJOR} = getIterationEstimatesWeeks(major);
+  const {MINORS_PER_MAJOR} = getIterationEstimatesWeeks(parseInt(major, 10) + diff);
   major = +major;
   minor = +minor;
 


### PR DESCRIPTION
When requesting previous iteration `getAdjacentIteration(-1)` I did not consider passing in the `diff` argument and it was not correctly selecting the `63` which has an exception for the majors/minors. 
Also the result of `current.number.split` is two strings (that's why the need to `parseInt`). 