### PR TITLE
Add tabs UI to feature view and other adjustments

### DIFF
--- a/src/content/components/FeatureView/FeatureView.js
+++ b/src/content/components/FeatureView/FeatureView.js
@@ -8,6 +8,8 @@ import {isBugResolved, runQuery} from "../../lib/utils";
 import {getIteration} from "../../../common/iterationUtils";
 import {BUGZILLA_PRODUCT, FILE_NEW_BUGZILLA_COMPONENT} from "../../../config/project_settings";
 
+import {NavLink, Route, Switch} from "react-router-dom";
+
 const currentIteration = getIteration().number;
 const currentRelease = currentIteration.split(".")[0];
 const prevRelease = parseInt(currentRelease, 10) - 1;
@@ -33,16 +35,67 @@ const allColumns = displayColumns.concat([
   "flags",
   upliftTrackingField,
   `cf_status_firefox${prevRelease}`,
-  `cf_status_firefox${currentRelease}`
+  `cf_status_firefox${currentRelease}`,
+  "cf_last_resolved"
 ]);
 
 function isBugUpliftCandidate(bug) {
   return ["?", "+", "blocking"].includes(bug.cf_tracking_beta) && !(["fixed", "verified"].includes(bug.cf_status_beta));
 }
 
+function sortByLastResolved(a, b) {
+  if (a.cf_last_resolved > b.cf_last_resolved) { return -1; }
+  if (a.cf_last_resolved < b.cf_last_resolved) { return 1; }
+  return 0;
+}
+
+const EngineeringView = props => {
+  const {bugs} = props;
+  return (<React.Fragment>
+
+    {bugs.untriaged.length ? (<React.Fragment><h3>Untriaged bugs</h3>
+      <BugList compact={true} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.untriaged} columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
+    </React.Fragment>) : ""}
+
+    {bugs.uplift.length ? (<React.Fragment><h3>Uplift candidates</h3>
+      <BugList compact={true} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.uplift} columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
+    </React.Fragment>) : ""}
+
+    <h3>Required for Current Release (Firefox {currentRelease})</h3>
+    <BugList compact={true} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.current} columns={displayColumns} />
+
+    <h3>Required for Next Release (Firefox {nextRelease})</h3>
+    <BugList compact={true} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.next} columns={displayColumns} />
+
+    <h3>Backlog</h3>
+    <BugList compact={true}showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.backlog} columns={displayColumns} />
+  </React.Fragment>);
+};
+
+const ResolvedView = props => (<React.Fragment>
+  <BugList
+    crossOutResolved={false}
+    showResolvedOption={false}
+    bulkEdit={true}
+    tags={true}
+    bugs={props.bugs.resolved}
+    columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
+</React.Fragment>);
+
+const tabConfig = [
+  {path: "", label: "Engineering", component: EngineeringView},
+  // {path: "/qa", label: "QA"},
+  {path: "/resolved", label: "Resolved", component: ResolvedView}
+  // TODO: replace resolve wiith these?
+  // {path: "/nightly", label: "Nightly"},
+  // {path: "/beta", label: "Beta"},
+  // {path: "/release", label: "Release"}
+];
+
 export class FeatureView extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.renderTabLink = this.renderTabLink.bind(this);
     this.state = {bugs: [], loaded: false};
   }
 
@@ -89,7 +142,7 @@ export class FeatureView extends React.PureComponent {
     result.current.sort(this.innerSort);
     result.next.sort(this.innerSort);
     result.backlog.sort(this.innerSort);
-    result.resolved.sort(this.innerSort);
+    result.resolved.sort(sortByLastResolved);
     return result;
   }
 
@@ -119,32 +172,38 @@ export class FeatureView extends React.PureComponent {
     return <a target="_blank" rel="noopener noreferrer" className={`${gStyles.primaryButton} ${gStyles.headerButton}`} href={url}>File new bug</a>;
   }
 
+  renderTabLink(tabInfo, i) {
+    return (<li key={i}>
+      <NavLink exact={true} activeClassName={styles.activeTab} to={this.props.match.url + tabInfo.path}>
+        {tabInfo.label}
+      </NavLink>
+    </li>);
+  }
+
+  renderTabRoute(bugsByRelease) {
+    return (tabInfo, i) => {
+      const WrapperComponent = tabInfo.component;
+      return (<Route
+        key={i}
+        exact={true}
+        path={this.props.match.url + tabInfo.path}
+        render={props => <WrapperComponent {...props} bugs={bugsByRelease} />} // eslint-disable-line
+        bugs={bugsByRelease} />);
+    };
+  }
+
   renderBugs(bugs) {
     const bugsByRelease = this.sortByRelease(this.state.bugs);
     return (<React.Fragment>
 
-      <h3>Untriaged bugs</h3>
-      <BugList showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugsByRelease.untriaged} columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
-
-      <h3>Uplift candidates</h3>
-      <BugList showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugsByRelease.uplift} columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
-
-      <h3>Required for Current Release (Firefox {currentRelease})</h3>
-      <BugList showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugsByRelease.current} columns={displayColumns} />
-
-      <h3>Required for Next Release (Firefox {nextRelease})</h3>
-      <BugList showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugsByRelease.next} columns={displayColumns} />
-
-      <h3>Backlog</h3>
-      <BugList showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugsByRelease.backlog} columns={displayColumns} />
-
-      <h3>Resolved</h3>
-      <BugList
-        showResolvedOption={false}
-        bulkEdit={true}
-        tags={true}
-        bugs={bugsByRelease.resolved}
-        columns={displayColumns} />
+      <div className={styles.tabsContainer}>
+        <ul>
+          {tabConfig.map(this.renderTabLink)}
+        </ul>
+      </div>
+      <Switch>
+        {tabConfig.map(this.renderTabRoute(bugsByRelease))}
+      </Switch>
     </React.Fragment>);
   }
 

--- a/src/content/components/FeatureView/FeatureView.js
+++ b/src/content/components/FeatureView/FeatureView.js
@@ -72,20 +72,25 @@ const EngineeringView = props => {
   </React.Fragment>);
 };
 
-const ResolvedView = props => (<React.Fragment>
-  <BugList
-    crossOutResolved={false}
-    showResolvedOption={false}
-    bulkEdit={true}
-    tags={true}
-    bugs={props.bugs.resolved}
-    columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
-</React.Fragment>);
+const ResolvedView = props => {
+  const {bugs} = props;
+  return (<React.Fragment>
+    {bugs.nightlyResolved.length ? (<React.Fragment><h3>Nightly Fix</h3>
+      <BugList crossOutResolved={false} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.nightlyResolved} columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
+    </React.Fragment>) : ""}
+    {bugs.betaResolved.length ? (<React.Fragment><h3>Beta Fix</h3>
+      <BugList crossOutResolved={false} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.betaResolved} columns={[...displayColumns, "cf_status_nightly", "cf_status_beta"]} />
+    </React.Fragment>) : ""}
+    {bugs.resolved.length ? (<React.Fragment><h3>Release Fix</h3>
+      <BugList crossOutResolved={false} showResolvedOption={false} bulkEdit={true} tags={true} bugs={bugs.resolved} columns={[...displayColumns, "target_milestone"]} />
+    </React.Fragment>) : ""}
+  </React.Fragment>);
+};
 
 const tabConfig = [
   {path: "", label: "Engineering", component: EngineeringView},
   // {path: "/qa", label: "QA"},
-  {path: "/resolved", label: "Ready to test", component: ResolvedView}
+  {path: "/qa", label: "Ready to test", component: ResolvedView}
   // TODO: replace resolve wiith these?
   // {path: "/nightly", label: "Nightly"},
   // {path: "/beta", label: "Beta"},
@@ -122,12 +127,18 @@ export class FeatureView extends React.PureComponent {
   }
 
   sortByRelease(bugs) {
-    const result = {resolved: [], untriaged: [], current: [], next: [], backlog: [], uplift: []};
+    const result = {nightlyResolved: [], betaResolved: [], resolved: [], untriaged: [], current: [], next: [], backlog: [], uplift: []};
     for (const bug of bugs) {
       if (isBugUpliftCandidate(bug)) {
         result.uplift.push(bug);
       } else if (isBugResolved(bug)) {
-        result.resolved.push(bug);
+        if (["fixed", "verified"].includes(bug.cf_status_beta)) {
+          result.betaResolved.push(bug);
+        } else if (["fixed", "verified"].includes(bug.cf_status_nightly)) {
+          result.nightlyResolved.push(bug);
+        } else {
+          result.resolved.push(bug);
+        }
       } else if (bug.priority === "P1") {
         result.current.push(bug);
       } else if (bug.priority === "P2") {
@@ -195,7 +206,6 @@ export class FeatureView extends React.PureComponent {
   renderBugs(bugs) {
     const bugsByRelease = this.sortByRelease(this.state.bugs);
     return (<React.Fragment>
-
       <div className={styles.tabsContainer}>
         <ul>
           {tabConfig.map(this.renderTabLink)}

--- a/src/content/components/FeatureView/FeatureView.js
+++ b/src/content/components/FeatureView/FeatureView.js
@@ -85,7 +85,7 @@ const ResolvedView = props => (<React.Fragment>
 const tabConfig = [
   {path: "", label: "Engineering", component: EngineeringView},
   // {path: "/qa", label: "QA"},
-  {path: "/resolved", label: "Resolved", component: ResolvedView}
+  {path: "/resolved", label: "Ready to test", component: ResolvedView}
   // TODO: replace resolve wiith these?
   // {path: "/nightly", label: "Nightly"},
   // {path: "/beta", label: "Beta"},

--- a/src/content/components/FeatureView/FeatureView.scss
+++ b/src/content/components/FeatureView/FeatureView.scss
@@ -1,8 +1,48 @@
+$tableBorderColor: rgba(0,0,0,0.1);
 .container {
   max-width: 900px;
   margin: 0 auto;
   padding: 20px 40px;
+  h3 {
+    padding-top: 0;
+  }
 }
 .subheading {
   text-align: center;
 }
+
+.tabsContainer {
+  padding-top: 30px;
+  margin-bottom: 20px;
+  // box-shadow: inset 0 -1px $tableBorderColor;
+  border-bottom: 1px solid #e5e5e5;
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    li {
+      a {
+        position: relative;
+        bottom: -1px;
+        text-decoration: none;
+        background: #FFF;
+        display: block;
+        font-weight: 600;
+        padding: 10px 14px;
+        border: 1px solid #FFF;
+        border-bottom-color: #e5e5e5;
+        color: #949494;
+        &.activeTab {
+          border-color: #e5e5e5;
+          border-radius: 3px 3px 0 0;
+          border-bottom-color: #FFF;
+          opacity: 1;
+          color: inherit;
+        }
+      }
+    }
+  }
+
+}
+

--- a/src/content/components/Router/Router.js
+++ b/src/content/components/Router/Router.js
@@ -173,6 +173,7 @@ export class Router extends React.PureComponent {
       },
       {
         label: "Feature",
+        exact: false,
         routeProps: {
           path: "/feature/:id",
           render: props => <FeatureView {...props} metas={this.props.metas} />
@@ -277,7 +278,7 @@ export class Router extends React.PureComponent {
           <Route exact={true} path={`/feature/${POCKET_META}`}><Redirect to="/pocket-newtab" /></Route>
           {ROUTER_CONFIG
             .filter(route => route.routeProps && !route.navOnly)
-            .map((route, index) => (<Route exact={true} key={index} {...route.routeProps} />))}
+            .map((route, index) => (<Route exact={route.exact !== false} key={index} {...route.routeProps} />))}
         </Switch>
       </main>
       <PriorityGuide />


### PR DESCRIPTION
Adds some basic tab UI that splits up FeatureView into 2 sections for
now; this is pretty rough but we can expand in the future (for example,
it would be nice to split up the queries to actually only fetch resolved
bugs if we have to.)

Also changes the BugLists to use the "compact" styles and sorts resolved
bugs by resolved date (cf_last_resolved).