### PR TITLE
Set new export bug type to task

### DIFF
--- a/src/content/components/Exports/Exports.js
+++ b/src/content/components/Exports/Exports.js
@@ -62,7 +62,7 @@ export class Exports extends React.PureComponent {
     if (!lastFiledExportBug) {
       return null;
     }
-    const url = `https://bugzilla.mozilla.org/enter_bug.cgi?dependson=${lastFiledExportBug.id}&bug_severity=enhancement&component=Activity%20Streams%3A%20Newtab&priority=P2&product=Firefox&short_desc=%5BExport%5D%20Add%20...%20to%20Activity%20Stream&status_whiteboard=%5Bexport%5D`;
+    const url = `https://bugzilla.mozilla.org/enter_bug.cgi?dependson=${lastFiledExportBug.id}&bug_severity=enhancement&bug_type=task&component=Activity%20Streams%3A%20Newtab&priority=P2&product=Firefox&short_desc=%5BExport%5D%20Add%20...%20to%20Activity%20Stream&status_whiteboard=%5Bexport%5D`;
     return <a target="_blank" rel="noopener noreferrer" className={`${gStyles.primaryButton} ${gStyles.headerButton}`} href={url}>File new bug</a>;
   }
 


### PR DESCRIPTION
r?@k88hudson I've been creating export as task to make the depends list show it separately from enhancement bugs. This won't work correctly until https://bugzilla.mozilla.org/show_bug.cgi?id=1543456 is deployed to bmo. 