### PR TITLE
Bug 134 - Typo in feature list note description

### DIFF
--- a/src/content/components/FeatureList/FeatureList.js
+++ b/src/content/components/FeatureList/FeatureList.js
@@ -79,7 +79,7 @@ export class FeatureList extends React.PureComponent {
     return (<div className={styles.container}>
       <h1>Feature List {this.renderAddNewFeature()}</h1>
       <p className={styles.subheading}>Note: To add a feature to sidebar, set the priority of the meta bug to <strong>P1</strong>.<br/>
-        Setting your feature to <strong>P1</strong> will prioritize it for for the current release and <strong>P2</strong> for the next.</p>
+        Setting your feature to <strong>P1</strong> will prioritize it for the current release and <strong>P2</strong> for the next.</p>
       {!empty ? (<table className={styles.featureTable}>
         {this.renderTableHead("Meta Bug", `Prioritized for Firefox ${release}`)}
         {this.renderTableBody(bugs.now)}


### PR DESCRIPTION
Fixed a typo where there was a double "for for" in the feature list description.