### PR TITLE
(nobug) - Update page title for feature/container using hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     "prettier", // "require("eslint-plugin-prettier")
     "import", // require("eslint-plugin-import")
     "react", // require("eslint-plugin-react")
+    "react-hooks", // require("eslint-plugin-react-hooks")
   ],
   extends: [
     "plugin:mozilla/recommended", // require("eslint-plugin-mozilla")
@@ -41,5 +42,8 @@ module.exports = {
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-direct-mutation-state": 2,
+
+    "react-hooks/rules-of-hooks": 2,
+    "react-hooks/exhaustive-deps": 1,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5033,6 +5033,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+      "integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -10906,28 +10912,82 @@
       }
     },
     "react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "react-dom": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
       }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
     },
     "react-router": {
       "version": "4.2.0",
@@ -11393,6 +11453,16 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "scss-tokenizer": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.10.0",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "husky": "^0.14.3",
     "mocha": "5.1.1",
     "node-sass": "^4.12.0",
@@ -55,8 +56,8 @@
     "parcel-bundler": "^1.12.3",
     "postcss-modules": "1.1.0",
     "prettier": "^1.17.1",
-    "react": "16.3.2",
-    "react-dom": "16.3.2",
+    "react": "16.8.6",
+    "react-dom": "16.8.6",
     "react-router-dom": "4.2.2",
     "ts-node": "^7.0.1",
     "typescript": "^3.4.5"

--- a/src/content/components/FeatureView/FeatureView.js
+++ b/src/content/components/FeatureView/FeatureView.js
@@ -477,7 +477,8 @@ export class FeatureView extends React.PureComponent {
             </a>{" "}
             <CopyButton text={metaId} title="Copy bug number" />
           </React.Fragment>
-        }>
+        }
+        title={metaDisplayName}>
         <CompletionBar bugs={this.state.bugs} />
         <Tabs
           baseUrl={this.props.match.url}

--- a/src/content/components/ui/Container/Container.js
+++ b/src/content/components/ui/Container/Container.js
@@ -1,30 +1,41 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styles from "./Container.scss";
 import gStyles from "../../../styles/gStyles.scss";
 import { Loader } from "../../Loader/Loader";
 import { FileNewBugButton } from "../FileNewBugButton/FileNewBugButton";
 
-export const Container = props => (
-  <div className={styles.container}>
-    <header className={styles.header}>
-      <h1>
-        {props.heading}{" "}
-        {props.fileBug ? (
-          <FileNewBugButton
-            className={gStyles.headerButton}
-            params={props.fileBug}
-          />
+export const Container = props => {
+  // Update the page's title for this container
+  useEffect(() => {
+    const prefix = `${
+      typeof props.heading == "string" ? props.heading : props.title
+    } – `;
+    document.title = prefix + document.title;
+    return () => (document.title = document.title.replace(prefix, ""));
+  }, [props.heading, props.title]);
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1>
+          {props.heading}{" "}
+          {props.fileBug ? (
+            <FileNewBugButton
+              className={gStyles.headerButton}
+              params={props.fileBug}
+            />
+          ) : (
+            ""
+          )}
+        </h1>
+        {props.subHeading ? (
+          <p className={styles.subHeading}>{props.subHeading}</p>
         ) : (
           ""
         )}
-      </h1>
-      {props.subHeading ? (
-        <p className={styles.subHeading}>{props.subHeading}</p>
-      ) : (
-        ""
-      )}
-    </header>
+      </header>
 
-    {props.loaded ? props.children : <Loader />}
-  </div>
-);
+      {props.loaded ? props.children : <Loader />}
+    </div>
+  );
+};


### PR DESCRIPTION
r?@k88hudson Adds react/dom 16.8.3 (to match activity-stream but maybe should just do 16.8.6 like in #138 ?) I added a dummy commit in the middle so prettier can reformat the braced function to avoid obscuring the actual changes in the last commit.

Not sure if better to…
- check for a title-able prop string (as implemented heading string or separate title)
- only use new title string prop
- reach into heading prop to grab the anchor text or use heading as string
- not do this from Container

Before (left tab) and after (right tab)
![Screen Shot 2019-06-12 at 10 59 18 PM](https://user-images.githubusercontent.com/438537/59407709-fa7a2400-8d66-11e9-90e0-73e5d650e7f9.png)

