### PR TITLE
Introduce caching for longer loading views

### DIFF
--- a/src/bin/buildRange.ts
+++ b/src/bin/buildRange.ts
@@ -80,8 +80,8 @@ const REFERENCE_RELEASES: ReleaseDefinition[] = [
   },
   {
     startVersion: 98,
-    iterationsPattern: [2, 2]
-  }
+    iterationsPattern: [2, 2],
+  },
 ];
 
 export interface IterationLookup {

--- a/src/config/pref_defaults.js
+++ b/src/config/pref_defaults.js
@@ -1,5 +1,8 @@
 module.exports = {
   // The user's bugzilla email
   bugzilla_email: "",
+  // Disable all client-side network requests
   offline_debug: false,
+  // Disable the user cache for bug views
+  disable_cache: false,
 };

--- a/src/content/components/ActiveRSMessages/ActiveRSMessages.tsx
+++ b/src/content/components/ActiveRSMessages/ActiveRSMessages.tsx
@@ -203,7 +203,7 @@ export class ActiveRSMessages extends React.PureComponent {
             <td key={i}>
               {" "}
               {message.content.buttons
-                ? message.content.buttons.primary.action.type
+                ? message.content.buttons.primary?.action?.type
                 : "None"}{" "}
             </td>
           );

--- a/src/content/components/IterationView/IterationView.tsx
+++ b/src/content/components/IterationView/IterationView.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { BugList } from "../BugList/BugList";
-import { useBugFetcher, Bug } from "../../hooks/useBugFetcher";
+import { useBugFetcher, Bug, BugQuery } from "../../hooks/useBugFetcher";
 import { Container } from "../ui/Container/Container";
 import { getIteration } from "../../../common/iterationUtils";
 import { Tabs } from "../ui/Tabs/Tabs";
+import { Loader, MiniLoader } from "../Loader/Loader";
 import { CompletionBar } from "../CompletionBar/CompletionBar";
 import { isBugResolved } from "../../lib/utils";
 import { emails } from "../../../config/people";
@@ -30,7 +31,7 @@ const COLUMNS = [
   "cf_fx_points",
 ];
 
-const getQuery = (options: GetQueryOptions) => ({
+const getQuery = (options: GetQueryOptions): BugQuery => ({
   include_fields: [
     "id",
     "summary",
@@ -106,7 +107,7 @@ interface SortByMetaReturn {
 function sortByMeta(allMetas: Array<MetaBug>, bugs: any[]): SortByMetaReturn {
   let bugsByMeta = {};
 
-  bugs.forEach(bug => {
+  bugs?.forEach(bug => {
     const metas = allMetas.filter(
       meta => meta.priority === "P1" && bug.blocks.includes(meta.id)
     );
@@ -207,9 +208,10 @@ const IterationViewTab: React.FunctionComponent<IterationViewTabProps> = props =
           </li>
         );
       })}
+      <MiniLoader hidden={!state.awaitingNetwork} />
     </React.Fragment>
   ) : (
-    <p>Loading...</p>
+    <Loader />
   );
 };
 

--- a/src/content/components/Loader/Loader.js
+++ b/src/content/components/Loader/Loader.js
@@ -1,4 +1,22 @@
-import styles from "./Loader.scss";
-import React from "react";
+import loaderStyles from "./Loader.scss";
+import miniLoaderStyles from "./MiniLoader.css";
+import React, { useState } from "react";
 
-export const Loader = () => <div className={styles.loader}>Loading...</div>;
+export const Loader = () => (
+  <div className={loaderStyles.loaderContainer}>
+    <div className={loaderStyles.loader}>Loading...</div>
+  </div>
+);
+
+export const MiniLoader = props => {
+  const [stopped, setStopped] = useState(null);
+  return (
+    <div
+      className={miniLoaderStyles.miniLoader}
+      hidden={props.hidden}
+      stopped={stopped}
+      onTransitionEnd={() => setStopped("")}>
+      <span>Refreshing...</span>
+    </div>
+  );
+};

--- a/src/content/components/Loader/Loader.scss
+++ b/src/content/components/Loader/Loader.scss
@@ -58,3 +58,13 @@
     height: 5em;
   }
 }
+.loaderContainer {
+  animation: fadein1 1s;
+}
+@keyframes fadein1 {
+  from {
+    opacity: 0;
+  }
+  to {
+  }
+}

--- a/src/content/components/Loader/MiniLoader.css
+++ b/src/content/components/Loader/MiniLoader.css
@@ -1,0 +1,100 @@
+/* Copyright (c) 2022 by Nobuaki Honma (https://codepen.io/nobuakihonma/pen/dYbqLQ)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+
+.miniLoader {
+  --loader-color: var(--ink-90);
+  --load-ping-timing-function: cubic-bezier(0.075, 0.82, 0.165, 1);
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 2em;
+  height: 24px;
+  width: 24px;
+  text-indent: -9999em;
+  transition: 0.5s opacity;
+}
+.miniLoader[hidden] {
+  opacity: 0;
+}
+.miniLoader[stopped] {
+  display: none;
+}
+.miniLoader span {
+  display: block;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  height: 24px;
+  width: 24px;
+}
+.miniLoader span::before,
+.miniLoader span::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  height: 24px;
+  width: 24px;
+  border: 2px solid var(--loader-color);
+  border-radius: 50%;
+  opacity: 0;
+  -webkit-animation: miniLoader-1 1.5s var(--load-ping-timing-function) infinite;
+  animation: miniLoader-1 1.5s var(--load-ping-timing-function) infinite;
+}
+@-webkit-keyframes miniLoader-1 {
+  0% {
+    -webkit-transform: translate3d(0, 0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    -webkit-transform: translate3d(0, 0, 0) scale(1.5);
+    opacity: 0;
+  }
+}
+@keyframes miniLoader-1 {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.5);
+    opacity: 0;
+  }
+}
+.miniLoader span::after {
+  -webkit-animation: miniLoader-2 1.5s var(--load-ping-timing-function) 0.25s
+    infinite;
+  animation: miniLoader-2 1.5s var(--load-ping-timing-function) 0.25s infinite;
+}
+@-webkit-keyframes miniLoader-2 {
+  0% {
+    -webkit-transform: translate3d(0, 0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    -webkit-transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0;
+  }
+}
+@keyframes miniLoader-2 {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0;
+  }
+}

--- a/src/content/components/OtherView/OtherView.tsx
+++ b/src/content/components/OtherView/OtherView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BugList } from "../BugList/BugList";
 import { useBugFetcher, Bug, BugQuery } from "../../hooks/useBugFetcher";
 import { Container } from "../ui/Container/Container";
+import { Loader } from "../Loader/Loader";
 
 const COLUMNS = ["id", "summary", "priority", "last_change_time"];
 
@@ -91,7 +92,7 @@ export const OtherView: React.FC<OtherViewProps> = props => {
           columns={COLUMNS}
         />
       ) : (
-        <p>Loading...</p>
+        <Loader />
       )}
     </Container>
   );

--- a/src/content/components/Router/Router.scss
+++ b/src/content/components/Router/Router.scss
@@ -2,6 +2,7 @@
   padding: 12px;
   flex-shrink: 0;
   width: 220px;
+  overflow: auto;
   background: #f9f9fa;
   font-size: 14px;
   font-weight: 500;
@@ -48,6 +49,7 @@
 }
 
 .main {
+  position: relative;
   flex-grow: 1;
   overflow: auto;
 }

--- a/src/content/lib/cache.js
+++ b/src/content/lib/cache.js
@@ -1,18 +1,14 @@
 import { prefs } from "./prefs";
 
-class Cache {
+class BugsCache {
   constructor({ version } = {}) {
-    if (!version) {
-      throw new Error("Cache version is required");
-    }
+    if (!version) throw new Error("Cache version is required");
     this._opened = false;
     this._version = version;
   }
 
   _open() {
-    if (prefs.get("disable_cache")) {
-      return null;
-    }
+    if (prefs.get("disable_cache")) return null;
     try {
       const cache = window.caches.open(this._version);
       if (!this._opened) {
@@ -29,7 +25,7 @@ class Cache {
   async get(request) {
     try {
       const cache = await this._open();
-      return cache && cache.match(request);
+      return cache.match(request.asGet);
     } catch (error) {
       console.debug("Error accessing cache :>> ", error);
       return null;
@@ -37,12 +33,10 @@ class Cache {
   }
 
   async set(request, response) {
-    if (!response) {
-      return false;
-    }
+    if (!response) return null;
     try {
       const cache = await this._open();
-      return cache && cache.put(request, response.clone());
+      return cache.put(request.asGet, response.clone());
     } catch (error) {
       console.debug("Error accessing cache :>> ", error);
       return null;
@@ -52,7 +46,7 @@ class Cache {
   async delete(request, options) {
     try {
       const cache = await this._open();
-      return cache && cache.delete(request, options);
+      return cache.delete(request.asGet, options);
     } catch (error) {
       console.debug("Error accessing cache :>> ", error);
       return null;
@@ -60,9 +54,7 @@ class Cache {
   }
 
   async purge() {
-    if (prefs.get("disable_cache")) {
-      return null;
-    }
+    if (prefs.get("disable_cache")) return null;
     try {
       const keys = await window.caches.keys();
       return Promise.all(keys.map(key => window.caches.delete(key)));
@@ -73,9 +65,7 @@ class Cache {
   }
 
   async update() {
-    if (prefs.get("disable_cache")) {
-      return null;
-    }
+    if (prefs.get("disable_cache")) return null;
     try {
       // Remove caches for old versions
       const keys = await window.caches.keys();
@@ -88,6 +78,55 @@ class Cache {
   }
 }
 
-export const cache = new Cache({ version: "1" });
+/**
+ * POST requests are not cacheable, and GET requests are not allowed to have a
+ * body. So we convert POST requests to GET requests for the purpose of caching.
+ * The real POST request is sent to the server, but within the cache it's keyed
+ * by the GET format.
+ */
+export class CacheableRequest extends Request {
+  /**
+   * Same as `new Request(input, options)` but with a method to convert to GET.
+   * @param {string|Request} input e.g. "/api/bugs"
+   * @param {object} options RequestInit options - important ones:
+   * @param {HeadersInit} [options.headers] Headers for the request
+   * @param {BodyInit} [options.body] e.g. a JSON string
+   * @param {string} [options.method] e.g. "POST"
+   */
+  constructor(
+    input,
+    {
+      body,
+      method = "POST",
+      headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      ...options
+    } = {}
+  ) {
+    super(input, { ...options, body, method, headers });
+    this.path = input;
+    this.body = body;
+  }
 
-module.exports.cache = cache;
+  /**
+   * Return this request, converted to a fake GET request, so it can be cached
+   * (returns itself if it's already a GET request).
+   * @returns {Request|this} A GET request with the same path as the original
+   *                         request, but with the body converted to a query
+   * @example $ new CacheableRequest("/api/bugs", { body: { id: 1 } }).asGet;
+   *          > new Request(`/api/bugs?fakebody={"id":1}`);
+   */
+  get asGet() {
+    if (this.method === "GET") return this;
+    return new Request(`${this.path}?fakebody=${this.body}`);
+  }
+}
+
+export const cache = new BugsCache({ version: "1" });
+
+module.exports = {
+  CacheableRequest,
+  cache,
+};

--- a/src/content/lib/cache.js
+++ b/src/content/lib/cache.js
@@ -1,0 +1,93 @@
+import { prefs } from "./prefs";
+
+class Cache {
+  constructor({ version } = {}) {
+    if (!version) {
+      throw new Error("Cache version is required");
+    }
+    this._opened = false;
+    this._version = version;
+  }
+
+  _open() {
+    if (prefs.get("disable_cache")) {
+      return null;
+    }
+    try {
+      const cache = window.caches.open(this._version);
+      if (!this._opened) {
+        this.update();
+        this._opened = true;
+      }
+      return cache;
+    } catch (error) {
+      console.debug("Error accessing cache :>> ", error);
+      return null;
+    }
+  }
+
+  async get(request) {
+    try {
+      const cache = await this._open();
+      return cache && cache.match(request);
+    } catch (error) {
+      console.debug("Error accessing cache :>> ", error);
+      return null;
+    }
+  }
+
+  async set(request, response) {
+    if (!response) {
+      return false;
+    }
+    try {
+      const cache = await this._open();
+      return cache && cache.put(request, response.clone());
+    } catch (error) {
+      console.debug("Error accessing cache :>> ", error);
+      return null;
+    }
+  }
+
+  async delete(request, options) {
+    try {
+      const cache = await this._open();
+      return cache && cache.delete(request, options);
+    } catch (error) {
+      console.debug("Error accessing cache :>> ", error);
+      return null;
+    }
+  }
+
+  async purge() {
+    if (prefs.get("disable_cache")) {
+      return null;
+    }
+    try {
+      const keys = await window.caches.keys();
+      return Promise.all(keys.map(key => window.caches.delete(key)));
+    } catch (error) {
+      console.debug("Error accessing cache :>> ", error);
+      return null;
+    }
+  }
+
+  async update() {
+    if (prefs.get("disable_cache")) {
+      return null;
+    }
+    try {
+      // Remove caches for old versions
+      const keys = await window.caches.keys();
+      const toDelete = keys.filter(key => key !== this._version);
+      return Promise.all(toDelete.map(key => window.caches.delete(key)));
+    } catch (error) {
+      console.debug("Error accessing cache :>> ", error);
+      return null;
+    }
+  }
+}
+
+const cache = new Cache({ version: "1" });
+
+module.exports.cache = cache;

--- a/src/content/lib/cache.js
+++ b/src/content/lib/cache.js
@@ -88,6 +88,6 @@ class Cache {
   }
 }
 
-const cache = new Cache({ version: "1" });
+export const cache = new Cache({ version: "1" });
 
 module.exports.cache = cache;

--- a/src/content/lib/postProcess.js
+++ b/src/content/lib/postProcess.js
@@ -3,17 +3,19 @@ const release = getIteration().number.split(".")[0];
 const prevRelease = release - 1;
 
 export function postProcess(resp) {
-  const bugs = resp.bugs.map(bug => {
-    if (`cf_status_firefox${release}` in bug) {
-      bug.cf_status_nightly = bug[`cf_status_firefox${release}`];
-    }
-    if (`cf_status_firefox${prevRelease}` in bug) {
-      bug.cf_status_beta = bug[`cf_status_firefox${prevRelease}`];
-    }
-    if (`cf_tracking_firefox${prevRelease}` in bug) {
-      bug.cf_tracking_beta = bug[`cf_tracking_firefox${prevRelease}`];
-    }
-    return bug;
-  });
+  const bugs =
+    resp.bugs &&
+    resp.bugs.map(bug => {
+      if (`cf_status_firefox${release}` in bug) {
+        bug.cf_status_nightly = bug[`cf_status_firefox${release}`];
+      }
+      if (`cf_status_firefox${prevRelease}` in bug) {
+        bug.cf_status_beta = bug[`cf_status_firefox${prevRelease}`];
+      }
+      if (`cf_tracking_firefox${prevRelease}` in bug) {
+        bug.cf_tracking_beta = bug[`cf_tracking_firefox${prevRelease}`];
+      }
+      return bug;
+    });
   return Object.assign({}, resp, bugs);
 }

--- a/src/content/lib/prefs.js
+++ b/src/content/lib/prefs.js
@@ -42,6 +42,6 @@ class Prefs {
   }
 }
 
-const prefs = new Prefs({ store: new Store() });
+export const prefs = new Prefs({ store: new Store() });
 
 module.exports.prefs = prefs;


### PR DESCRIPTION
- Implement a basic cache for bug lists.
- When entering a view, first try to render from cached data, then start fetching from the server and update when data is received.
- Views show a subtle loading indicator when they have rendered from cached data but are currently fetching fresh data.
  - I figured this would be helpful since some views (like the triage view) take a very long time, and it would otherwise be hard to feel confident you're looking at the current state.
  - This doesn't interfere with displaying the normal loading indicator when no cached data was found for that view.
- Old caches can be invalidated by changing the version parameter in cache.js (there are ways to "expire" caches automatically - I will look into that and appreciate any advice)

EDIT: Btw, forgot to mention this also fixes the RS Messages view crash.

Fixes #188